### PR TITLE
support a grade of "None"

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -290,6 +290,20 @@ Running total commitment: 90245
 <BLANKLINE>
 <BLANKLINE>
 
+If *initial_grade* is ``None``, the mapping table will still be used but annual
+increments will not be processed which means that the total expenditure and
+commitments will be lower:
+
+>>> expenditure, commitments, explanations = ucamstaffoncosts.employment_expenditure_and_commitments(
+...     until_date, None, initial_point, scheme, start_date=start_date,
+...     from_date=from_date, next_anniversary_date=next_anniversary_date,
+...     scale_table=EXAMPLE_SALARY_SCALES)
+>>> expenditure
+14837
+>>> commitments
+87258
+
+
 Reference
 ---------
 

--- a/ucamstaffoncosts/salary/scales.py
+++ b/ucamstaffoncosts/salary/scales.py
@@ -230,7 +230,16 @@ class SalaryScaleTable:
             ...
         ValueError: point "P5" is not part of grade "Grade.GRADE_1"
 
+        If the grade is ``None``, the "increment" will always return the input grade.
+
+        >>> EXAMPLE_SALARY_SCALES.increment(None, 'P5')
+        'P5'
+
         """
+        # If grade is Nonwe, just return point
+        if grade is None:
+            return point
+
         # Get salary scale for grade
         scale = self.scale_for_grade(grade)
 

--- a/ucamstaffoncosts/salary/scales.py
+++ b/ucamstaffoncosts/salary/scales.py
@@ -236,7 +236,7 @@ class SalaryScaleTable:
         'P5'
 
         """
-        # If grade is Nonwe, just return point
+        # If grade is None, just return point
         if grade is None:
             return point
 


### PR DESCRIPTION
If the grade is "None", we still use the point in the mapping tables but annual increments do not occur. This allows one to model unknown grades as being mapped to a single salary spine point for the duration of the employment.

We want to do this in the PI dashboard where we get a salary scale point for an individual but no clear idea of Grade.